### PR TITLE
add nfs-common package to cluster nodes

### DIFF
--- a/odroid-bootstrap.yml
+++ b/odroid-bootstrap.yml
@@ -70,6 +70,11 @@
           }
       notify: Restart unattended-upgrades service
 
+    - name: install packages
+      ansible.builtin.package:
+        name:
+          - nfs-common
+
     - name: Start unattended-upgrades service
       ansible.builtin.systemd:
         name: unattended-upgrades


### PR DESCRIPTION
The nfs-common package is required to enable the k8s nodes to mount
nfs shares from the synology NAS.